### PR TITLE
Track Auto-Rotation

### DIFF
--- a/src/main/java/robomuss/rc/block/BlockTrack.java
+++ b/src/main/java/robomuss/rc/block/BlockTrack.java
@@ -15,6 +15,8 @@ import robomuss.rc.item.ItemTrain;
 import robomuss.rc.item.RCItems;
 import robomuss.rc.track.TrackHandler;
 import robomuss.rc.track.piece.TrackPiece;
+import robomuss.rc.track.piece.TrackPieceCorner;
+import robomuss.rc.track.piece.TrackPieceHorizontal;
 import robomuss.rc.util.IPaintable;
 
 public class BlockTrack extends BlockContainer implements IPaintable {
@@ -36,7 +38,7 @@ public class BlockTrack extends BlockContainer implements IPaintable {
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(World var1, int var2) {
+	public TileEntity createNewTileEntity(World world, int metadata) {
 		return new TileEntityTrack();
 	}
 
@@ -59,7 +61,6 @@ public class BlockTrack extends BlockContainer implements IPaintable {
 				else {
 					return false;
 				}
-				
 			}
 			else {
 				return false;
@@ -100,6 +101,8 @@ public class BlockTrack extends BlockContainer implements IPaintable {
     	if(world.getTileEntity(x, y, z) != null && world.getTileEntity(x, y, z) instanceof TileEntityTrack) {
 	    	TileEntityTrack te = (TileEntityTrack) world.getTileEntity(x, y, z);
 	    	te.type = TrackHandler.findTrackStyle("corkscrew");
+
+		    updateRotation(world, x, y, z, te);
     	}
     }
     
@@ -115,4 +118,151 @@ public class BlockTrack extends BlockContainer implements IPaintable {
         	}
         }
     }
+
+	private void updateRotation(World world, int x, int y, int z, TileEntityTrack track) {          //may be better way of doing this, but it works
+		if (!world.isRemote) {
+			Block blockWest = world.getBlock(x - 1, y, z);              //west
+			Block blockEast = world.getBlock(x + 1, y, z);              //east
+			Block blockNorth = world.getBlock(x, y, z - 1);             //north
+			Block blockSouth = world.getBlock(x, y, z + 1);             //south
+
+			if (isHorizontal(this)) {
+				if (isBlockTrack(blockWest)) {
+					if (isCorner(blockWest)) {
+						TileEntityTrack teWest = (TileEntityTrack) world.getTileEntity(x - 1, y, z);
+						if (teWest.direction == 1 || teWest.direction == 2) {
+							track.direction = 1;
+						}
+					} else if (isHorizontal(blockWest)) {
+						TileEntityTrack teWest = (TileEntityTrack) world.getTileEntity(x - 1, y, z);
+						if (teWest.direction == 1 || teWest.direction == 3) {
+							track.direction = teWest.direction;
+						}
+					}
+				}
+
+				if(isBlockTrack(blockEast)) {
+					if (isCorner(blockEast)) {
+						TileEntityTrack teEast = (TileEntityTrack) world.getTileEntity(x + 1, y, z);
+						if (teEast.direction == 0 || teEast.direction == 3) {
+							track.direction = 1;
+						}
+					} else if (isHorizontal(blockEast)) {
+						TileEntityTrack teEast = (TileEntityTrack) world.getTileEntity(x + 1, y, z);
+						if (teEast.direction == 1 || teEast.direction == 3) {
+							track.direction = teEast.direction;
+						}
+					}
+				}
+
+				if (isBlockTrack(blockNorth)) {
+					if (isCorner(blockNorth)) {
+						TileEntityTrack teNorth = (TileEntityTrack) world.getTileEntity(x, y, z - 1);
+						if (teNorth.direction == 2 || teNorth.direction == 3) {
+							track.direction = 0;
+						}
+					}
+				}
+
+				if (isBlockTrack(blockSouth)) {
+					if (isCorner(blockSouth)) {
+						TileEntityTrack teSouth = (TileEntityTrack) world.getTileEntity(x, y, z + 1);
+						if (teSouth.direction == 0 || teSouth.direction == 1) {
+							track.direction = 0;
+						}
+					}
+				}
+			}
+
+			if (isCorner(this)) {
+				if (isBlockTrack(blockWest)) {
+					if (isHorizontal(blockWest)) {
+						TileEntityTrack teWest = (TileEntityTrack) world.getTileEntity(x - 1, y, z);
+
+						if (teWest.direction == 1 || teWest.direction == 3) {
+							track.direction = 3;
+
+							if (isBlockTrack(blockNorth)) {
+								if (isHorizontal(blockNorth)) {
+									TileEntityTrack teNorth = (TileEntityTrack) world.getTileEntity(x, y, z - 1);
+									if (teNorth.direction == 0 || teNorth.direction == 2) {
+										track.direction = 0;
+									}
+								}
+							}
+
+							if (isBlockTrack(blockSouth)) {
+								if (isHorizontal(blockSouth)) {
+									TileEntityTrack teSouth = (TileEntityTrack) world.getTileEntity(x, y, z + 1);
+									if (teSouth.direction == 0 || teSouth.direction == 2) {
+										track.direction = 3;
+									}
+								}
+							}
+						}
+					}
+				}
+
+				if (isBlockTrack(blockEast)) {
+					if (isHorizontal(blockEast)) {
+						TileEntityTrack teEast = (TileEntityTrack) world.getTileEntity(x + 1, y, z);
+
+						if (teEast.direction == 1 || teEast.direction == 3) {
+							track.direction = 1;
+
+							if (isBlockTrack(blockNorth)) {
+								if (isHorizontal(blockNorth)) {
+									TileEntityTrack teNorth = (TileEntityTrack) world.getTileEntity(x, y, z - 1);
+									if (teNorth.direction == 0 || teNorth.direction == 2) {
+										track.direction = 1;
+									}
+								}
+							}
+
+							if (isBlockTrack(blockSouth)) {
+								if (isHorizontal(blockSouth)) {
+									TileEntityTrack teSouth = (TileEntityTrack) world.getTileEntity(x, y, z + 1);
+									if (teSouth.direction == 0 || teSouth.direction == 2) {
+										track.direction = 2;
+									}
+								}
+							}
+						}
+					}
+				}
+
+				if (isBlockTrack(blockNorth)) {
+					if (isHorizontal(blockNorth)) {
+						TileEntityTrack teNorth = (TileEntityTrack) world.getTileEntity(x, y, z - 1);
+						if (teNorth.direction == 0 || teNorth.direction == 2) {
+							track.direction = 0;
+						}
+					}
+				}
+
+				if (isBlockTrack(blockSouth)) {
+					if (isHorizontal(blockSouth)) {
+						TileEntityTrack teSouth = (TileEntityTrack) world.getTileEntity(x, y, z + 1);
+						if (teSouth.direction == 0 || teSouth.direction == 2) {
+							track.direction = 2;
+						}
+					}
+				}
+			}
+
+			world.markBlockForUpdate(x, y, z);
+		}
+	}
+
+	private boolean isBlockTrack(Block block) {
+		return block instanceof BlockTrack;
+	}
+
+	private boolean isHorizontal(Block block) {
+		return ((BlockTrack) block).track_type instanceof TrackPieceHorizontal;
+	}
+
+	private boolean isCorner(Block block) {
+		return ((BlockTrack) block).track_type instanceof TrackPieceCorner;
+	}
 }


### PR DESCRIPTION
Horizontal track pieces and corner pieces now automatically rotate when placed adjacent to other horizontal/corner piece tracks. If a corner track is placed adjacent to a single horizontal track, it will rotate to favor a right-hand turn, such that one click from the Hammer in Rotate Mode will make it a left-hand turn. If a corner piece is placed adjacent to two horizontal pieces at a 90 degree angle, it will rotate to the appropriate  direction for the adjacent tracks.
