### PR TITLE
Some Improvements to Slopes

### DIFF
--- a/src/main/java/robomuss/rc/block/BlockDummy.java
+++ b/src/main/java/robomuss/rc/block/BlockDummy.java
@@ -1,0 +1,199 @@
+package robomuss.rc.block;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockContainer;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.particle.EffectRenderer;
+import net.minecraft.client.particle.EntityDiggingFX;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+import robomuss.rc.block.te.TileEntityDummy;
+import robomuss.rc.block.te.TileEntityTrack;
+import robomuss.rc.track.piece.TrackPieceSlope;
+import robomuss.rc.track.piece.TrackPieceSlopeDown;
+import robomuss.rc.track.piece.TrackPieceSlopeUp;
+
+import java.util.Random;
+
+public class BlockDummy extends BlockContainer {
+	private int slopeLocX, slopeLocY, slopeLocZ;
+	private TileEntityTrack teSlope;
+	private BlockTrack blockSlope;
+	private Random rand = new Random();
+
+	private boolean breakSlope = true;
+	private int slopeDirection;
+
+	private IIcon[] icons = new IIcon[3];
+
+	public BlockDummy() {
+		super(Material.iron);
+		setHardness(1F);
+		setHardness(3F);
+	}
+
+	/* Dummy blocks are always invisible, this grabs the BlockTrack icon for applying to the destroy/hit particles of the dummy block. */
+	@Override
+	public IIcon getIcon(int side, int meta) {
+		if (blockSlope == null) {
+//			System.out.println("blockSlope null!");
+		} else if (blockSlope.track_type instanceof TrackPieceSlopeUp) {
+			return icons[0];
+		} else if (blockSlope.track_type instanceof TrackPieceSlope) {
+			return icons[1];
+		} else if (blockSlope.track_type instanceof TrackPieceSlopeDown) {
+			return icons[2];
+		}
+		return this.blockIcon;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void registerBlockIcons(IIconRegister iconRegister) {
+		this.icons[0] = iconRegister.registerIcon("rc:tracks/slope_up");
+		this.icons[1] = iconRegister.registerIcon("rc:tracks/slope");
+		this.icons[2] = iconRegister.registerIcon("rc:tracks/slope_down");
+		this.blockIcon = iconRegister.registerIcon("rc:tracks/horizontal");
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean addHitEffects(World world, MovingObjectPosition position, EffectRenderer renderer) {
+		int x = position.blockX;
+		int y = position.blockY;
+		int z = position.blockZ;
+
+		Block block = world.getBlock(x, y, z);
+		if (block == null) {
+			return false;
+		}
+
+		int side = position.sideHit;
+
+		float i = 0.1F;
+		double posX = x + rand.nextDouble() * (block.getBlockBoundsMaxX() - block.getBlockBoundsMinX() - (i * 2.0F)) + i + block.getBlockBoundsMinX();
+		double posY = y + rand.nextDouble() * (block.getBlockBoundsMaxY() - block.getBlockBoundsMinY() - (i * 2.0F)) + i + block.getBlockBoundsMinY();
+		double posZ = z + rand.nextDouble() * (block.getBlockBoundsMaxZ() - block.getBlockBoundsMinZ() - (i * 2.0F)) + i + block.getBlockBoundsMinZ();
+
+		if (side == 4) posX = x + block.getBlockBoundsMinX() - i;
+		if (side == 5) posX = x + block.getBlockBoundsMaxX() + i;
+		if (side == 0) posY = y + block.getBlockBoundsMinY() - i;
+		if (side == 1) posY = y + block.getBlockBoundsMaxY() + i;
+		if (side == 2) posZ = z + block.getBlockBoundsMinZ() - i;
+		if (side == 3) posZ = z + block.getBlockBoundsMaxZ() + i;
+
+		EntityDiggingFX diggingFX = new EntityDiggingFX(world, posX, posY, posZ, 0.0D, 0.0D, 0.0D, block, side, world.getBlockMetadata(x, y, z));
+		diggingFX.setParticleIcon(getIcon(0, 0));
+		renderer.addEffect(diggingFX.applyColourMultiplier(x, y, z).multiplyVelocity(0.2F).multipleParticleScaleBy(0.6F));
+		return true;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean addDestroyEffects(World world, int x, int y, int z, int meta, EffectRenderer renderer) {
+		Block block = world.getBlock(x, y, z);
+		if (block == null) {
+			return false;
+		}
+
+		byte b0 = 4;
+		for (int i = 0; i < b0; ++i) {
+			for (int j = 0; j < b0; ++j) {
+				for (int k = 0; k < b0; ++k) {
+					double px = x + (i + 0.5D) / b0;
+					double py = y + (j + 0.5D) / b0;
+					double pz = z + (k + 0.5D) / b0;
+
+					int random = rand.nextInt(6);
+
+					EntityDiggingFX fx = new EntityDiggingFX(world, px, py, pz, px - x - 0.5D, py - y - 0.5D, pz - z - 0.5D, this, random, meta);
+					fx.setParticleIcon(getIcon(0, 0));
+					renderer.addEffect(fx.applyColourMultiplier(x, y, z));
+				}
+			}
+		}
+
+		return true;
+	}
+
+	@Override
+	public TileEntity createNewTileEntity(World world, int direction) {
+		return new TileEntityDummy();
+	}
+
+	@Override
+	public void setBlockBoundsBasedOnState(IBlockAccess iba, int x, int y, int z) {
+		setBlockBounds(0, 0, 0, 1, 1, 1);
+	}
+
+	@Override
+	public boolean isOpaqueCube() {
+		return false;
+	}
+
+	@Override
+	public int getRenderType() {
+		return -1;
+	}
+
+	@Override
+	public boolean renderAsNormalBlock() {
+		return false;
+	}
+
+	@Override
+	public void onBlockAdded(World world, int x, int y, int z) {
+//		System.out.println("Dummy Added to World!");
+	}
+
+	@Override
+	public void onBlockHarvested(World world, int x, int y, int z, int meta, EntityPlayer player) {         //passed in coords are those of this block
+//		if (player.capabilities.isCreativeMode) {
+//			System.out.println("Player in creative.");
+//			System.out.println(getBreakSlope());
+			if (getBreakSlope()) {
+				world.setBlockToAir(slopeLocX, slopeLocY, slopeLocZ);
+				world.markBlockForUpdate(slopeLocX, slopeLocY, slopeLocZ);
+				world.setBlockToAir(x, y, z);
+				world.markBlockForUpdate(x, y, z);
+			} else {
+				world.setBlockToAir(x, y, z);
+				world.markBlockForUpdate(x, y, z);
+			}
+//		}
+	}
+
+	public void setBreakSlope(boolean breakSlope) {
+		this.breakSlope = breakSlope;
+	}
+
+	public boolean getBreakSlope() {
+		return this.breakSlope;
+	}
+
+//	public void setSlopeDirection(int direction) {
+//		this.slopeDirection = direction;
+//	}
+
+	public void setParentSlope(TileEntityTrack te, BlockTrack track) {
+		this.slopeLocX = te.xCoord;
+		this.slopeLocY = te.yCoord;
+		this.slopeLocZ = te.zCoord;
+		this.slopeDirection = te.direction;
+		this.teSlope = te;
+		this.blockSlope = track;
+//		System.out.printf("Parent slope set: %d, %d, %d, %b, %b", slopeLocX, slopeLocY, slopeLocZ, teSlope != null, blockSlope != null);
+//		System.out.println();
+	}
+
+	public BlockTrack getParentSlope() {
+		return blockSlope;
+	}
+}

--- a/src/main/java/robomuss/rc/block/BlockTrack.java
+++ b/src/main/java/robomuss/rc/block/BlockTrack.java
@@ -3,31 +3,33 @@ package robomuss.rc.block;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import robomuss.rc.block.te.TileEntityDummy;
 import robomuss.rc.block.te.TileEntityTrack;
 import robomuss.rc.entity.EntityTrainDefault;
 import robomuss.rc.item.ItemExtra;
 import robomuss.rc.item.ItemTrain;
 import robomuss.rc.item.RCItems;
 import robomuss.rc.track.TrackHandler;
-import robomuss.rc.track.piece.TrackPiece;
-import robomuss.rc.track.piece.TrackPieceCorner;
-import robomuss.rc.track.piece.TrackPieceHorizontal;
+import robomuss.rc.track.piece.*;
 import robomuss.rc.util.IPaintable;
 
 public class BlockTrack extends BlockContainer implements IPaintable {
-
 	public TrackPiece track_type;
+
+	Block blockWest, blockEast, blockNorth, blockSouth, blockSlope;
 	
 	public BlockTrack(TrackPiece track) {
 		super(Material.iron);
 		setHardness(1F);
 		setResistance(3F);
-		
+
 		this.track_type = track;
 	}
 	
@@ -99,8 +101,35 @@ public class BlockTrack extends BlockContainer implements IPaintable {
     @Override
     public void onBlockAdded(World world, int x, int y, int z) {
     	if(world.getTileEntity(x, y, z) != null && world.getTileEntity(x, y, z) instanceof TileEntityTrack) {
+//		    System.out.println("Track Added!");
 	    	TileEntityTrack te = (TileEntityTrack) world.getTileEntity(x, y, z);
 	    	te.type = TrackHandler.findTrackStyle("corkscrew");
+
+		    findNeighborBlocks(world, x, y, z);
+
+		    if (isBlockTrack(this)) {
+			    if (isSlopeUp(this) || isSlope(this) || isSlopeDown(this)) {
+				    blockSlope = this;
+				    switch (te.direction) {
+					    case 0:
+						    BlockDummy dummySouth = (BlockDummy) RCBlocks.dummy;
+						    placeDummy(world, x, y, z + 1, dummySouth, te, te.direction, true);
+						    break;
+					    case 1:
+							BlockDummy dummyWest = (BlockDummy) RCBlocks.dummy;
+						    placeDummy(world, x - 1, y, z, dummyWest, te, te.direction, true);
+						    break;
+					    case 2:
+						    BlockDummy dummyNorth = (BlockDummy) RCBlocks.dummy;
+							placeDummy(world, x, y, z - 1, dummyNorth, te, te.direction, true);
+						    break;
+					    case 3:
+						    BlockDummy dummyEast = (BlockDummy) RCBlocks.dummy;
+						    placeDummy(world, x + 1, y, z, dummyEast, te, te.direction, true);
+						    break;
+				    }
+			    }
+		    }
 
 		    updateRotation(world, x, y, z, te);
     	}
@@ -116,16 +145,92 @@ public class BlockTrack extends BlockContainer implements IPaintable {
 	                world.spawnEntityInWorld(entity);
 	            }
         	}
+
+	        //TODO: MUST CHECK ALL NEIGHBORS!!!
+//	        if (!(world.getBlock(x, y, z + 1) instanceof BlockDummy) && te.direction != 0) {
+//		        BlockDummy newDummy = (BlockDummy) RCBlocks.dummy;
+//		        placeDummy(world, x, y, z + 1, newDummy, te, te.direction, true);
+//	        } else if (!(world.getBlock(x - 1, y, z) instanceof BlockDummy) && te.direction != 1) {
+//		        BlockDummy newDummy = (BlockDummy) RCBlocks.dummy;
+//		        placeDummy(world, x - 1, y, z, newDummy, te, te.direction, true);
+//	        } else if (!(world.getBlock(x, y, z - 1) instanceof BlockDummy) && te.direction != 2) {
+//		        BlockDummy newDummy = (BlockDummy) RCBlocks.dummy;
+//		        placeDummy(world, x, y, z - 1, newDummy, te, te.direction, true);
+//	        } else if (!(world.getBlock(x + 1, y, z) instanceof BlockDummy) && te.direction != 3) {
+//		        BlockDummy newDummy = (BlockDummy) RCBlocks.dummy;
+//		        placeDummy(world, x + 1, y, z, newDummy, te, te.direction, true);
+//	        }
         }
     }
 
-	private void updateRotation(World world, int x, int y, int z, TileEntityTrack track) {          //may be better way of doing this, but it works
-		if (!world.isRemote) {
-			Block blockWest = world.getBlock(x - 1, y, z);              //west
-			Block blockEast = world.getBlock(x + 1, y, z);              //east
-			Block blockNorth = world.getBlock(x, y, z - 1);             //north
-			Block blockSouth = world.getBlock(x, y, z + 1);             //south
+	@Override
+	public void onBlockHarvested(World world, int trackX, int trackY, int trackZ, int meta, EntityPlayer player) {
+//		if (player.capabilities.isCreativeMode) {                                                                   //TODO: check that this works in survival
+			if (world.getTileEntity(trackX, trackY, trackZ) instanceof TileEntityTrack) {
+				TileEntityTrack te = (TileEntityTrack) world.getTileEntity(trackX, trackY, trackZ);
+				findNeighborBlocks(world, trackX, trackY, trackZ);
+				if (isSlopeUp(this)) {
+					switch (te.direction) {
+						case 0:
+							if (world.getBlock(trackX, trackY, trackZ + 1) instanceof BlockDummy) {                 //check if block z + 1 is a dummy
+								BlockDummy dummySouth = (BlockDummy) world.getBlock(trackX, trackY, trackZ + 1);    //obtain the dummy
+								dummySouth.setBreakSlope(false);                                                    //tell dummy to not attempt to break the slope
+								dummySouth.onBlockHarvested(world, trackX, trackY, trackZ + 1, meta, player);
+								world.markBlockForUpdate(trackX, trackY, trackZ + 1);
+							}
+							break;
+						case 1:
+							if (world.getBlock(trackX - 1, trackY, trackZ) instanceof BlockDummy) {
+								BlockDummy dummyWest = (BlockDummy) world.getBlock(trackX - 1, trackY, trackZ);
+								dummyWest.setBreakSlope(false);
+								dummyWest.onBlockHarvested(world, trackX - 1, trackY, trackZ, meta, player);
+								world.markBlockForUpdate(trackX - 1, trackY, trackZ);
+							}
+							break;
+						case 2:
+							if (world.getBlock(trackX, trackY, trackZ - 1) instanceof BlockDummy) {
+								BlockDummy dummyNorth = (BlockDummy) world.getBlock(trackX, trackY, trackZ - 1);
+								dummyNorth.setBreakSlope(false);
+								dummyNorth.onBlockHarvested(world, trackX, trackY, trackZ - 1, meta, player);
+								world.markBlockForUpdate(trackX, trackY, trackZ - 1);
+							}
+							break;
+						case 3:
+							if (world.getBlock(trackX + 1, trackY, trackZ) instanceof BlockDummy) {
+								BlockDummy dummyEast = (BlockDummy) world.getBlock(trackX + 1, trackY, trackZ);
+								dummyEast.setBreakSlope(false);
+								dummyEast.onBlockHarvested(world, trackX + 1, trackY, trackZ, meta, player);
+								world.markBlockForUpdate(trackX + 1, trackY, trackZ);
+							}
+							break;
+					}
+					world.setBlockToAir(trackX, trackY, trackZ);
+					world.markBlockForUpdate(trackX, trackY, trackZ);
+				}
+			}
+//		}
+	}
 
+	private void findNeighborBlocks(World world, int x, int y, int z) {
+		if (!world.isRemote) {
+			blockWest = world.getBlock(x - 1, y, z);              //west
+			blockEast = world.getBlock(x + 1, y, z);              //east
+			blockNorth = world.getBlock(x, y, z - 1);             //north
+			blockSouth = world.getBlock(x, y, z + 1);             //south
+		}
+	}
+
+	/**
+	 * Depending on the type of track piece, this handles auto-rotation and/or rotation of complex track pieces (ie. slopes).
+	 * Coordinates and the TileEntity passed in are those of the track block being rotated.
+	 * @param world
+	 * @param x
+	 * @param y
+	 * @param z
+	 * @param track
+	 */
+	public void updateRotation(World world, int x, int y, int z, TileEntityTrack track) {          //may be better way of doing this, but it works
+		if (!world.isRemote) {
 			if (isHorizontal(this)) {
 				if (isBlockTrack(blockWest)) {
 					if (isCorner(blockWest)) {
@@ -250,8 +355,70 @@ public class BlockTrack extends BlockContainer implements IPaintable {
 				}
 			}
 
+			if (isSlopeUp(this)) {
+//				System.out.println(track.direction);
+				findNeighborBlocks(world, x, y, z);
+				if (track.direction == 1 && blockSouth instanceof BlockDummy) {
+					if (this.equals(((BlockDummy) blockSouth).getParentSlope())) {
+//						System.out.println("Slopes are equal!");
+					}
+					TileEntityDummy dummy = (TileEntityDummy) world.getTileEntity(x, y, z + 1);
+					((BlockDummy) blockSouth).setBreakSlope(false);
+					blockSouth.onBlockHarvested(world, dummy.xCoord, dummy.yCoord, dummy.zCoord, 0, Minecraft.getMinecraft().thePlayer);
+					world.markBlockForUpdate(dummy.xCoord, dummy.yCoord, dummy.zCoord);
+					BlockDummy newDummy = (BlockDummy) RCBlocks.dummy;
+					placeDummy(world, x - 1, y, z, newDummy, track, track.direction, true);
+				} else if (track.direction == 2 && blockWest instanceof BlockDummy) {
+					TileEntityDummy dummy = (TileEntityDummy) world.getTileEntity(x - 1, y, z);
+					((BlockDummy) blockWest).setBreakSlope(false);
+					blockWest.onBlockHarvested(world, dummy.xCoord, dummy.yCoord, dummy.zCoord, 0, Minecraft.getMinecraft().thePlayer);
+					world.markBlockForUpdate(dummy.xCoord, dummy.yCoord, dummy.zCoord);
+					BlockDummy newDummy = (BlockDummy) RCBlocks.dummy;
+					placeDummy(world, x, y, z - 1, newDummy, track, track.direction, true);
+				} else if (track.direction == 3 && blockNorth instanceof BlockDummy) {
+					TileEntityDummy dummy = (TileEntityDummy) world.getTileEntity(x, y, z - 1);
+					((BlockDummy) blockNorth).setBreakSlope(false);
+					blockNorth.onBlockHarvested(world, dummy.xCoord, dummy.yCoord, dummy.zCoord, 0, Minecraft.getMinecraft().thePlayer);
+					world.markBlockForUpdate(dummy.xCoord, dummy.yCoord, dummy.zCoord);
+					BlockDummy newDummy = (BlockDummy) RCBlocks.dummy;
+					placeDummy(world, x + 1, y, z, newDummy, track, track.direction, true);
+				} else if (track.direction == 0 && blockEast instanceof BlockDummy) {
+					TileEntityDummy dummy = (TileEntityDummy) world.getTileEntity(x + 1, y, z);
+					((BlockDummy) blockEast).setBreakSlope(false);
+					blockEast.onBlockHarvested(world, dummy.xCoord, dummy.yCoord, dummy.zCoord, 0, Minecraft.getMinecraft().thePlayer);
+					world.markBlockForUpdate(dummy.xCoord, dummy.yCoord, dummy.zCoord);
+					BlockDummy newDummy = (BlockDummy) RCBlocks.dummy;
+					placeDummy(world, x, y, z + 1, newDummy, track, track.direction, true);
+				}
+//				if (!(blockSouth instanceof BlockDummy) && !(blockWest instanceof BlockDummy) && !(blockNorth instanceof BlockDummy) && !(blockEast instanceof BlockDummy)) {
+//					BlockDummy dummy = (BlockDummy) RCBlocks.dummy;
+//					switch (track.direction) {
+//						case 0:
+//							placeDummy(world, x, y, z + 1, dummy, track, track.direction, true);
+//							break;
+//						case 1:
+//							placeDummy(world, x - 1, y, z, dummy, track, track.direction, true);
+//							break;
+//						case 2:
+//							placeDummy(world, x, y, z - 1, dummy, track, track.direction, true);
+//							break;
+//						case 3:
+//							placeDummy(world, x + 1, y, z, dummy, track, track.direction, true);
+//							break;
+//					}
+//				}
+			}
+
 			world.markBlockForUpdate(x, y, z);
 		}
+	}
+
+	public void placeDummy(World world, int dummyX, int dummyY, int dummyZ, BlockDummy dummy, TileEntityTrack teSlope, int slopeDirection, boolean breakSlope) {
+		world.setBlock(dummyX, dummyY, dummyZ, dummy);
+		teSlope.setDummy(dummy, dummyX, dummyY, dummyZ);
+		dummy.setParentSlope(teSlope, this);
+//		dummy.setSlopeDirection(slopeDirection);
+		dummy.setBreakSlope(breakSlope);
 	}
 
 	private boolean isBlockTrack(Block block) {
@@ -264,5 +431,17 @@ public class BlockTrack extends BlockContainer implements IPaintable {
 
 	private boolean isCorner(Block block) {
 		return ((BlockTrack) block).track_type instanceof TrackPieceCorner;
+	}
+
+	private boolean isSlopeUp(Block block) {
+		return ((BlockTrack) block).track_type instanceof TrackPieceSlopeUp;
+	}
+
+	private boolean isSlope(Block block) {
+		return ((BlockTrack) block).track_type instanceof TrackPieceSlope;
+	}
+
+	private boolean isSlopeDown(Block block) {
+		return ((BlockTrack) block).track_type instanceof TrackPieceSlopeDown;
 	}
 }

--- a/src/main/java/robomuss/rc/block/RCBlocks.java
+++ b/src/main/java/robomuss/rc/block/RCBlocks.java
@@ -3,14 +3,7 @@ package robomuss.rc.block;
 
 import net.minecraft.block.Block;
 import robomuss.rc.RCMod;
-import robomuss.rc.block.te.TileEntityFooter;
-import robomuss.rc.block.te.TileEntityRideFence;
-import robomuss.rc.block.te.TileEntitySupport;
-import robomuss.rc.block.te.TileEntityTrack;
-import robomuss.rc.block.te.TileEntityTrackDesigner;
-import robomuss.rc.block.te.TileEntityTrackFabricator;
-import robomuss.rc.block.te.TileEntityTrackStorage;
-import robomuss.rc.block.te.TileEntityWoodenSupport;
+import robomuss.rc.block.te.*;
 import robomuss.rc.item.ItemBlockPath;
 import robomuss.rc.track.TrackHandler;
 import robomuss.rc.track.piece.TrackPiece;
@@ -21,7 +14,7 @@ public class RCBlocks {
 
 	public static int last_track_id;
 	public static Block support, woodenSupport, path, railings, picket, ride_fence, ride_fence_corner, ride_fence_triangle, ride_fence_square, ride_fence_gate, track_designer, track_fabricator, track_storage;
-	public static Block footer;
+	public static Block footer, dummy;
 	
 	public static void init() {
 		for(TrackPiece track: TrackHandler.pieces) {
@@ -47,6 +40,8 @@ public class RCBlocks {
 		ride_fence_gate = new BlockRideFence().setBlockName("ride_fence_gate").setBlockTextureName("rc:ride_fence_gate").setCreativeTab(RCMod.decor);
 		
 		footer = new BlockFooter().setBlockName("footer").setBlockTextureName("rc:footer").setCreativeTab(RCMod.track);
+
+		dummy = new BlockDummy().setBlockName("dummy");
 		
         GameRegistry.registerBlock(support, "support");
         GameRegistry.registerBlock(woodenSupport, "woodenSupport");
@@ -65,6 +60,8 @@ public class RCBlocks {
 		GameRegistry.registerBlock(ride_fence_gate, "ride_fence_gate");
 		
 		GameRegistry.registerBlock(footer, "footer");
+
+		GameRegistry.registerBlock(dummy, "dummy");
         
         GameRegistry.registerTileEntity(TileEntityTrackDesigner.class, "te_track_designer");
         GameRegistry.registerTileEntity(TileEntityTrackFabricator.class, "te_track_fabricator");
@@ -76,6 +73,8 @@ public class RCBlocks {
 		GameRegistry.registerTileEntity(TileEntityWoodenSupport.class, "te_woodenSupport");
 		
 		GameRegistry.registerTileEntity(TileEntityFooter.class, "te_footer");
+
+		GameRegistry.registerTileEntity(TileEntityDummy.class, "te_dummy");
 	}
 
 }

--- a/src/main/java/robomuss/rc/block/te/TileEntityDummy.java
+++ b/src/main/java/robomuss/rc/block/te/TileEntityDummy.java
@@ -1,0 +1,14 @@
+package robomuss.rc.block.te;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import robomuss.rc.track.style.TrackStyle;
+import sun.org.mozilla.javascript.internal.ast.Block;
+
+public class TileEntityDummy extends TileEntityTrack {
+	TrackStyle type;
+
+	public TileEntityDummy() {
+		this.type = super.type;
+	}
+}

--- a/src/main/java/robomuss/rc/block/te/TileEntityTrack.java
+++ b/src/main/java/robomuss/rc/block/te/TileEntityTrack.java
@@ -7,6 +7,10 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+import robomuss.rc.block.BlockDummy;
+import robomuss.rc.block.BlockTrack;
+import robomuss.rc.block.RCBlocks;
 import robomuss.rc.track.TrackHandler;
 import robomuss.rc.track.extra.TrackExtra;
 import robomuss.rc.track.piece.TrackPiece;
@@ -23,6 +27,9 @@ public class TileEntityTrack extends TileEntity {
 	public int colour;
 	public TrackExtra extra;
 	public TrackStyle type;
+
+	public BlockDummy dummy;
+	public int dummyX, dummyY, dummyZ;
 	
 	private boolean converted = false;
 	
@@ -94,6 +101,15 @@ public class TileEntityTrack extends TileEntity {
 	@Override
 	public boolean canUpdate() {
 		return false;
+	}
+
+	public void setDummy(Block block, int dummyX, int dummyY, int dummyZ) {
+		if (block instanceof BlockDummy) {
+			this.dummy = (BlockDummy) block;
+			this.dummyX = dummyX;
+			this.dummyY = dummyY;
+			this.dummyZ = dummyZ;
+		}
 	}
 
 	/*@Optional.Method(modid = "PneumaticCraft")

--- a/src/main/java/robomuss/rc/client/gui/GuiHammerOverlay.java
+++ b/src/main/java/robomuss/rc/client/gui/GuiHammerOverlay.java
@@ -24,6 +24,8 @@ public class GuiHammerOverlay extends GuiScreen {
 		this.minecraft = minecraft;
 	}
 
+	//TODO: fix player gui when in survival and looking at a track block.
+	//TODO: add a range limit to when this renders.
 	@SubscribeEvent(priority = EventPriority.NORMAL)
     public void eventHandler(RenderGameOverlayEvent event) {
 		MovingObjectPosition pos = rayTraceMouse();

--- a/src/main/java/robomuss/rc/item/ItemHammer.java
+++ b/src/main/java/robomuss/rc/item/ItemHammer.java
@@ -9,12 +9,14 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import robomuss.rc.block.BlockTrack;
 import robomuss.rc.block.te.TileEntityFooter;
 import robomuss.rc.block.te.TileEntityRideFence;
 import robomuss.rc.block.te.TileEntitySupport;
 import robomuss.rc.block.te.TileEntityTrack;
 import robomuss.rc.block.te.TileEntityWoodenSupport;
 import robomuss.rc.track.TrackHandler;
+import robomuss.rc.track.piece.TrackPieceSlopeUp;
 import robomuss.rc.util.hammer.HammerMode;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -27,12 +29,22 @@ public class ItemHammer extends Item {
 			public void onRightClick(TileEntity tileentity, PlayerInteractEvent event) {
 				if(tileentity instanceof TileEntityTrack) {
 					TileEntityTrack tet = (TileEntityTrack) tileentity;
-					if(tet.direction == 3) {
-						tet.direction = 0;
+					if (event.world.getBlock(tet.xCoord, tet.yCoord, tet.zCoord) instanceof BlockTrack) {
+						BlockTrack track = (BlockTrack) event.world.getBlock(tet.xCoord, tet.yCoord, tet.zCoord);
+						if (track.track_type instanceof TrackPieceSlopeUp) {
+							if (tet.direction != 3) {
+								tet.direction++;
+							} else if (tet.direction == 3) {
+								tet.direction = 0;
+							}
+							track.updateRotation(event.world, tet.xCoord, tet.yCoord, tet.zCoord, tet);
+						} else if(tet.direction == 3) {
+							tet.direction = 0;
+						} else {
+							tet.direction++;
+						}
 					}
-					else {
-						tet.direction++;
-					}
+
 					event.world.markBlockForUpdate(event.x, event.y, event.z);
 				}
 				if(tileentity instanceof TileEntityRideFence) {

--- a/src/main/java/robomuss/rc/track/TrackHandler.java
+++ b/src/main/java/robomuss/rc/track/TrackHandler.java
@@ -15,14 +15,7 @@ import robomuss.rc.track.extra.TrackExtra;
 import robomuss.rc.track.extra.TrackExtraAirLauncher;
 import robomuss.rc.track.extra.TrackExtraChain;
 import robomuss.rc.track.extra.TrackExtraStation;
-import robomuss.rc.track.piece.TrackPiece;
-import robomuss.rc.track.piece.TrackPieceCorner;
-import robomuss.rc.track.piece.TrackPieceHeartlineRoll;
-import robomuss.rc.track.piece.TrackPieceHorizontal;
-import robomuss.rc.track.piece.TrackPieceLoop;
-import robomuss.rc.track.piece.TrackPieceSlope;
-import robomuss.rc.track.piece.TrackPieceSlopeDown;
-import robomuss.rc.track.piece.TrackPieceSlopeUp;
+import robomuss.rc.track.piece.*;
 import robomuss.rc.track.style.TrackStyle;
 
 public class TrackHandler {
@@ -45,13 +38,14 @@ public class TrackHandler {
 	}
 	
 	public static void addTrackPieces() {
-		TrackHandler.pieces.add(new TrackPieceHorizontal("horizontal", 3));
-		TrackHandler.pieces.add(new TrackPieceSlopeUp("slope_up", 3, 2));
-		TrackHandler.pieces.add(new TrackPieceSlope("slope", 3));
-		TrackHandler.pieces.add(new TrackPieceSlopeDown("slope_down", 3, 2));
-		TrackHandler.pieces.add(new TrackPieceCorner("curve", 3));
-		TrackHandler.pieces.add(new TrackPieceLoop("loop", 10, 2));
-		TrackHandler.pieces.add(new TrackPieceHeartlineRoll("heartline_roll", 12, 19));
+		pieces.add(new TrackPieceHorizontal("horizontal", 3));
+		pieces.add(new TrackPieceSlopeUp("slope_up", 3, 2));
+		pieces.add(new TrackPieceSlope("slope", 3));
+		pieces.add(new TrackPieceSlopeDown("slope_down", 3, 2));
+		pieces.add(new TrackPieceCorner("curve", 3));
+		pieces.add(new TrackPieceLoop("loop", 10, 2));
+		pieces.add(new TrackPieceHeartlineRoll("heartline_roll", 12, 19));
+//		pieces.add(new TrackDummy("dummy", 0));
 	}
 	
 	public static void addTrackExtras() {


### PR DESCRIPTION
Slope Up track pieces now place a dummy block when added to the world.
The function of this block is to simply be a hitbox to make placing the
next slope piece easier and more intuitive. Slope and Slope Down track
pieces do not yet have this functionality, but will in the near future,
I wanted to get this onto github. The Rotation Mode of the Hammer was
also modified to accomodate the new dummy block. When rotating a Slope
Up track piece, the Hammer tells the track to break the dummy, rotate,
then replace the dummy in a new location. Known Issues:

1: If two Slope Up track pieces are rotated/positioned such that their
dummy blocks overlap, the dummy of one piece will not exist after the
other rotates, this is not much of an issue, as all it does is remove
the convenience, the Slope Up track with the missing dummy simply needs
to be replaced. This will be fixed in the next push.

2: If a Slope Up track block is adjacent to any block and is rotated to
face the block, the block will be destroyed when the slope places it's
dummy again. This will be fixed in the next push.

3: The hammer overlay causes the player UI to pull from the wrong
texture sheet when looking at a track in survival (the hearts, hunger,
and experience).

4: All types of slopes do not currently have auto-rotate functionality.
I'm trying to refine the dummy placement mechanics first.

5: Right clicking with the Hammer on a dummy block does not do anything. I am trying to think of a good way to handle rotation if clicking on the dummy.

6: Anything I may have overlooked...

As a result of implementing this functionality, I am further tempted to
make a near-complete rewrite of the BlockTrack class, though I do not
know the exact details of how things would be laid out.
